### PR TITLE
fix(github): add workflow permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,6 @@
 name: Publish Docker image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Soli0222/note-tweet-connector/security/code-scanning/1](https://github.com/Soli0222/note-tweet-connector/security/code-scanning/1)

To resolve this issue, you should explicitly set the least-required permissions for the GITHUB_TOKEN in this workflow. The best location is at the root of the workflow file (just beneath the `name:`), ensuring all jobs inherit the setting unless overridden. For the shown workflow, the job only checks out code (`actions/checkout`) and manages Docker images, so it does not need any `write` permissions to the repository. The minimum effective permissions are `contents: read`, which suffices for checking out code. Add:

```yaml
permissions:
  contents: read
```

directly under the workflow `name:` line. No additional imports, definitions or changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
