### PR TITLE
feat(note2tweet): 公開されていないノートとローカルノートをスキップする条件を追加

### DIFF
--- a/internal/handler/note2tweet.go
+++ b/internal/handler/note2tweet.go
@@ -49,6 +49,22 @@ func Note2TweetHandler(ctx context.Context, data []byte, contentTracker *tracker
 		return err
 	}
 
+	if payload.Body.Note.Visibility != "public" {
+		slog.Info("Note is not public, skipping",
+			slog.String("note_id", payload.Body.Note.ID),
+			slog.String("visibility", payload.Body.Note.Visibility))
+		m.Note2TweetSkipped.WithLabelValues("not_public").Inc()
+		return nil
+	}
+
+	if payload.Body.Note.LocalOnly {
+		slog.Info("Note is local only, skipping",
+			slog.String("note_id", payload.Body.Note.ID),
+			slog.Bool("local_only", payload.Body.Note.LocalOnly))
+		m.Note2TweetSkipped.WithLabelValues("local_only").Inc()
+		return nil
+	}
+
 	noteText := payload.Body.Note.Text
 	noteURI := payload.Server + "/notes/" + payload.Body.Note.ID
 
@@ -74,14 +90,6 @@ func Note2TweetHandler(ctx context.Context, data []byte, contentTracker *tracker
 			slog.String("note_id", payload.Body.Note.ID),
 			slog.String("text_preview", escapedText[:min(50, len(escapedText))]))
 		m.Note2TweetSkipped.WithLabelValues("rt_pattern").Inc()
-		return nil
-	}
-
-	if payload.Body.Note.Visibility != "public" {
-		slog.Info("Note is not public, skipping",
-			slog.String("note_id", payload.Body.Note.ID),
-			slog.String("visibility", payload.Body.Note.Visibility))
-		m.Note2TweetSkipped.WithLabelValues("not_public").Inc()
 		return nil
 	}
 

--- a/internal/handler/note2tweet_test.go
+++ b/internal/handler/note2tweet_test.go
@@ -246,6 +246,23 @@ func TestNote2TweetHandler_SkipConditions(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "skip local only note",
+			payload: `{
+				"body": {
+					"note": {
+						"id": "note-local-only",
+						"text": "Local only note",
+						"visibility": "public",
+						"localOnly": true,
+						"files": [],
+						"cw": null
+					}
+				},
+				"server": "https://misskey.example"
+			}`,
+			wantErr: false,
+		},
+		{
 			name: "skip home visibility",
 			payload: `{
 				"body": {


### PR DESCRIPTION
- Note2TweetHandlerで、ノートの可視性が「public」でない場合とローカルノートの場合にスキップするロジックを追加した。
- テストケースにローカルノートをスキップする条件を追加した。