### PR TITLE
feat(note2tweet): 引用リノートのトラッカーTweetIDを使用する機能を追加

### DIFF
--- a/internal/handler/note2tweet.go
+++ b/internal/handler/note2tweet.go
@@ -18,22 +18,32 @@ var rtAtPattern = regexp.MustCompile(`^RT\s*@`)
 
 var postTweet = twitter.Post
 var postTweetWithMedia = twitter.PostWithMedia
+var postTweetWithOptions = twitter.PostWithOptions
 
 type payloadNoteData struct {
 	Server string `json:"server"`
 	Body   struct {
 		Note struct {
 			ID         string        `json:"id"`
+			UserID     string        `json:"userId"`
 			Visibility string        `json:"visibility"`
 			LocalOnly  bool          `json:"localOnly"`
 			Files      []interface{} `json:"files"`
 			Cw         string        `json:"cw"`
 			Text       string        `json:"text"`
-			Renote     struct {
-				ID   string `json:"id"`
-				URI  string `json:"uri"`
-				Text string `json:"text"`
-				User struct {
+			RenoteID   string        `json:"renoteId"`
+			User       struct {
+				ID       string `json:"id"`
+				Host     string `json:"host"`
+				Username string `json:"username"`
+			} `json:"user"`
+			Renote struct {
+				ID     string `json:"id"`
+				UserID string `json:"userId"`
+				URI    string `json:"uri"`
+				Text   string `json:"text"`
+				User   struct {
+					ID       string `json:"id"`
 					Host     string `json:"host"`
 					Username string `json:"username"`
 				}
@@ -85,10 +95,29 @@ func Note2TweetHandler(ctx context.Context, data []byte, crossPostTracker *track
 
 	noteText := payload.Body.Note.Text
 	noteURI := payload.Server + "/notes/" + payload.Body.Note.ID
+	quoteTweetID := ""
 
 	if payload.Body.Note.Cw != "" {
 		circles := strings.Repeat("○", len(payload.Body.Note.Text))
 		noteText = payload.Body.Note.Cw + "\n" + circles + "\n" + noteURI
+	} else if isQuoteRenote(payload) {
+		if noteRenoteSameAuthor(payload) {
+			renoteID := payload.Body.Note.RenoteID
+			if renoteID == "" {
+				renoteID = payload.Body.Note.Renote.ID
+			}
+			if resolvedTweetID, ok := resolveTweetIDForMisskeyNote(crossPostTracker, renoteID); ok {
+				quoteTweetID = resolvedTweetID
+			} else {
+				slog.Info("Quote renote source not found in tracker",
+					slog.String("note_id", noteID),
+					slog.String("renote_id", renoteID))
+			}
+		} else {
+			slog.Info("Quote renote author mismatch, falling back to text",
+				slog.String("note_id", noteID),
+				slog.String("renote_id", payload.Body.Note.RenoteID))
+		}
 	}
 
 	if noteText == "" || noteText == "null" {
@@ -125,7 +154,13 @@ func Note2TweetHandler(ctx context.Context, data []byte, crossPostTracker *track
 	}
 
 	var tweetID string
-	if len(fileURLs) == 0 {
+	if quoteTweetID != "" {
+		tweetID, err = postTweetWithOptions(ctx, twitter.PostOptions{
+			Text:         noteText,
+			MediaURLs:    fileURLs,
+			QuoteTweetID: quoteTweetID,
+		})
+	} else if len(fileURLs) == 0 {
 		tweetID, err = postTweet(ctx, noteText)
 	} else {
 		tweetID, err = postTweetWithMedia(ctx, noteText, fileURLs)
@@ -142,6 +177,7 @@ func Note2TweetHandler(ctx context.Context, data []byte, crossPostTracker *track
 			slog.String("note_id", noteID),
 			slog.String("tweet_id", tweetID),
 			slog.String("text_preview", escapedText[:min(100, len(escapedText))]),
+			slog.String("quote_tweet_id", quoteTweetID),
 			slog.Bool("has_media", len(fileURLs) > 0),
 			slog.Int("media_count", len(fileURLs)))
 		m.Note2TweetSuccess.Inc()
@@ -154,6 +190,31 @@ func Note2TweetHandler(ctx context.Context, data []byte, crossPostTracker *track
 	}
 
 	return nil
+}
+
+func isQuoteRenote(payload *payloadNoteData) bool {
+	if payload.Body.Note.Text == "" || payload.Body.Note.Text == "null" {
+		return false
+	}
+	return payload.Body.Note.RenoteID != "" || payload.Body.Note.Renote.ID != ""
+}
+
+func noteRenoteSameAuthor(payload *payloadNoteData) bool {
+	if payload.Body.Note.UserID != "" && payload.Body.Note.Renote.UserID != "" {
+		return payload.Body.Note.UserID == payload.Body.Note.Renote.UserID
+	}
+	if payload.Body.Note.User.ID != "" && payload.Body.Note.Renote.User.ID != "" {
+		return payload.Body.Note.User.ID == payload.Body.Note.Renote.User.ID
+	}
+	return false
+}
+
+func resolveTweetIDForMisskeyNote(crossPostTracker *tracker.CrossPostTracker, noteID string) (string, bool) {
+	record, ok := crossPostTracker.FindByMisskeyNoteID(noteID)
+	if !ok || record.TweetID == "" {
+		return "", false
+	}
+	return record.TweetID, true
 }
 
 func parseNotePayload(data []byte) (*payloadNoteData, error) {

--- a/internal/handler/note2tweet_test.go
+++ b/internal/handler/note2tweet_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Soli0222/note-tweet-connector/internal/metrics"
 	"github.com/Soli0222/note-tweet-connector/internal/tracker"
+	"github.com/Soli0222/note-tweet-connector/internal/twitter"
 )
 
 func TestParseNotePayload(t *testing.T) {
@@ -365,6 +366,139 @@ func TestNote2TweetHandler_RecordsCrossPostIDs(t *testing.T) {
 	}
 	if !crossPostTracker.HasTweet("tweet-1") {
 		t.Fatal("tweet ID was not recorded")
+	}
+}
+
+func TestNote2TweetHandler_QuoteRenoteUsesTrackerTweetID(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	crossPostTracker.RememberMisskeyToTweet("source-note", "source-tweet")
+	m := metrics.NewNoop()
+
+	oldPost := postTweet
+	oldPostWithMedia := postTweetWithMedia
+	oldPostWithOptions := postTweetWithOptions
+	defer func() {
+		postTweet = oldPost
+		postTweetWithMedia = oldPostWithMedia
+		postTweetWithOptions = oldPostWithOptions
+	}()
+
+	postTweet = func(ctx context.Context, text string) (string, error) {
+		t.Fatal("Post should not be called for quote renote")
+		return "", nil
+	}
+	postTweetWithMedia = func(ctx context.Context, text string, fileURLs []string) (string, error) {
+		t.Fatal("PostWithMedia should not be called for quote renote")
+		return "", nil
+	}
+
+	var gotOptions twitter.PostOptions
+	postTweetWithOptions = func(ctx context.Context, options twitter.PostOptions) (string, error) {
+		gotOptions = options
+		return "quote-tweet", nil
+	}
+
+	payload := `{
+		"body": {
+			"note": {
+				"id": "quote-note",
+				"userId": "user-1",
+				"text": "My quote text",
+				"visibility": "public",
+				"localOnly": false,
+				"files": [],
+				"cw": null,
+				"renoteId": "source-note",
+				"renote": {
+					"id": "source-note",
+					"userId": "user-1",
+					"text": "source text",
+					"uri": "https://misskey.example/notes/source-note",
+					"user": {
+						"id": "user-1",
+						"username": "dummy"
+					}
+				},
+				"user": {
+					"id": "user-1",
+					"username": "dummy"
+				}
+			}
+		},
+		"server": "https://misskey.example"
+	}`
+
+	if err := Note2TweetHandler(ctx, []byte(payload), crossPostTracker, m); err != nil {
+		t.Fatalf("Note2TweetHandler() error = %v", err)
+	}
+	if gotOptions.Text != "My quote text" {
+		t.Fatalf("Text = %q, want My quote text", gotOptions.Text)
+	}
+	if gotOptions.QuoteTweetID != "source-tweet" {
+		t.Fatalf("QuoteTweetID = %q, want source-tweet", gotOptions.QuoteTweetID)
+	}
+	if !crossPostTracker.HasMisskeyNote("quote-note") || !crossPostTracker.HasTweet("quote-tweet") {
+		t.Fatal("quote cross-post IDs were not recorded")
+	}
+}
+
+func TestNote2TweetHandler_QuoteRenoteFallsBackWhenTrackerMiss(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	m := metrics.NewNoop()
+
+	oldPost := postTweet
+	oldPostWithOptions := postTweetWithOptions
+	defer func() {
+		postTweet = oldPost
+		postTweetWithOptions = oldPostWithOptions
+	}()
+
+	var gotText string
+	postTweet = func(ctx context.Context, text string) (string, error) {
+		gotText = text
+		return "tweet-fallback", nil
+	}
+	postTweetWithOptions = func(ctx context.Context, options twitter.PostOptions) (string, error) {
+		t.Fatal("PostWithOptions should not be called when quote source is not in tracker")
+		return "", nil
+	}
+
+	payload := `{
+		"body": {
+			"note": {
+				"id": "quote-note",
+				"userId": "user-1",
+				"text": "My quote text",
+				"visibility": "public",
+				"localOnly": false,
+				"files": [],
+				"cw": null,
+				"renoteId": "missing-source-note",
+				"renote": {
+					"id": "missing-source-note",
+					"userId": "user-1",
+					"text": "source text",
+					"user": {
+						"id": "user-1",
+						"username": "dummy"
+					}
+				},
+				"user": {
+					"id": "user-1",
+					"username": "dummy"
+				}
+			}
+		},
+		"server": "https://misskey.example"
+	}`
+
+	if err := Note2TweetHandler(ctx, []byte(payload), crossPostTracker, m); err != nil {
+		t.Fatalf("Note2TweetHandler() error = %v", err)
+	}
+	if gotText != "My quote text" {
+		t.Fatalf("posted text = %q, want My quote text", gotText)
 	}
 }
 

--- a/internal/handler/tweet2note.go
+++ b/internal/handler/tweet2note.go
@@ -68,7 +68,6 @@ type twitterUser struct {
 // RNとat記号の検出用正規表現
 var rnAtPattern = regexp.MustCompile(`^RN\s*\[at\]`)
 
-var createMisskeyNoteWithFiles = misskey.CreateNoteWithFiles
 var createMisskeyNoteWithOptions = misskey.CreateNoteWithOptions
 var uploadMisskeyDriveFileFromURL = misskey.UploadDriveFileFromURL
 

--- a/internal/handler/tweet2note.go
+++ b/internal/handler/tweet2note.go
@@ -15,11 +15,15 @@ import (
 )
 
 type IncomingTweet struct {
-	ID        string
-	Text      string
-	Username  string
-	URL       string
-	MediaURLs []string
+	ID             string
+	Text           string
+	UserID         string
+	Username       string
+	URL            string
+	MediaURLs      []string
+	QuotedTweetID  string
+	QuotedUserID   string
+	QuotedUsername string
 }
 
 type accountActivityPayload struct {
@@ -28,14 +32,16 @@ type accountActivityPayload struct {
 }
 
 type tweetObject struct {
-	IDStr            string          `json:"id_str"`
-	Text             string          `json:"text"`
-	FullText         string          `json:"full_text"`
-	Truncated        bool            `json:"truncated"`
-	User             twitterUser     `json:"user"`
-	Entities         twitterEntities `json:"entities"`
-	ExtendedEntities twitterEntities `json:"extended_entities"`
-	ExtendedTweet    extendedTweet   `json:"extended_tweet"`
+	IDStr             string          `json:"id_str"`
+	Text              string          `json:"text"`
+	FullText          string          `json:"full_text"`
+	Truncated         bool            `json:"truncated"`
+	User              twitterUser     `json:"user"`
+	Entities          twitterEntities `json:"entities"`
+	ExtendedEntities  twitterEntities `json:"extended_entities"`
+	ExtendedTweet     extendedTweet   `json:"extended_tweet"`
+	QuotedStatusIDStr string          `json:"quoted_status_id_str"`
+	QuotedStatus      *tweetObject    `json:"quoted_status"`
 }
 
 type extendedTweet struct {
@@ -63,6 +69,7 @@ type twitterUser struct {
 var rnAtPattern = regexp.MustCompile(`^RN\s*\[at\]`)
 
 var createMisskeyNoteWithFiles = misskey.CreateNoteWithFiles
+var createMisskeyNoteWithOptions = misskey.CreateNoteWithOptions
 var uploadMisskeyDriveFileFromURL = misskey.UploadDriveFileFromURL
 
 func Tweet2NoteHandler(ctx context.Context, data []byte, crossPostTracker *tracker.CrossPostTracker, m *metrics.Metrics) error {
@@ -100,6 +107,7 @@ func HandleIncomingTweet(ctx context.Context, tweet IncomingTweet, crossPostTrac
 	}
 
 	tweetText := tweet.Text
+	renoteID := ""
 
 	if rtAtPattern.MatchString(tweetText) {
 		tweetText = tweetText + "\n\n" + tweet.URL
@@ -112,6 +120,22 @@ func HandleIncomingTweet(ctx context.Context, tweet IncomingTweet, crossPostTrac
 			slog.String("text_preview", escapedText[:min(50, len(escapedText))]))
 		m.Tweet2NoteSkipped.WithLabelValues("rn_pattern").Inc()
 		return nil
+	}
+
+	if tweet.QuotedTweetID != "" {
+		if tweetQuoteSameAuthor(tweet) {
+			if resolvedNoteID, ok := resolveMisskeyNoteIDForTweet(crossPostTracker, tweet.QuotedTweetID); ok {
+				renoteID = resolvedNoteID
+			} else {
+				slog.Info("Quote tweet source not found in tracker",
+					slog.String("tweet_id", tweet.ID),
+					slog.String("quoted_tweet_id", tweet.QuotedTweetID))
+			}
+		} else {
+			slog.Info("Quote tweet author mismatch, falling back to text",
+				slog.String("tweet_id", tweet.ID),
+				slog.String("quoted_tweet_id", tweet.QuotedTweetID))
+		}
 	}
 
 	misskeyHost := os.Getenv("MISSKEY_HOST")
@@ -141,7 +165,11 @@ func HandleIncomingTweet(ctx context.Context, tweet IncomingTweet, crossPostTrac
 		fileIDs = append(fileIDs, fileID)
 	}
 
-	noteID, err := createMisskeyNoteWithFiles(ctx, misskeyHost, misskeyToken, tweetText, fileIDs)
+	noteID, err := createMisskeyNoteWithOptions(ctx, misskeyHost, misskeyToken, misskey.CreateNoteOptions{
+		Text:     tweetText,
+		FileIDs:  fileIDs,
+		RenoteID: renoteID,
+	})
 
 	if err == nil {
 		if noteID == "" {
@@ -155,6 +183,7 @@ func HandleIncomingTweet(ctx context.Context, tweet IncomingTweet, crossPostTrac
 			slog.String("note_id", noteID),
 			slog.String("text_preview", escapedText[:min(100, len(escapedText))]),
 			slog.String("tweet_url", tweet.URL),
+			slog.String("renote_id", renoteID),
 			slog.Bool("has_media", len(fileIDs) > 0),
 			slog.Int("media_count", len(fileIDs)))
 		m.Tweet2NoteSuccess.Inc()
@@ -190,16 +219,53 @@ func parseAccountActivityPayload(data []byte) ([]IncomingTweet, error) {
 		if username == "" {
 			username = os.Getenv("TWITTER_USERNAME")
 		}
+		quotedTweetID, quotedUserID, quotedUsername := quotedTweet(event)
 		tweets = append(tweets, IncomingTweet{
-			ID:        tweetID,
-			Text:      text,
-			Username:  username,
-			URL:       buildTweetURL(username, tweetID),
-			MediaURLs: mediaURLs,
+			ID:             tweetID,
+			Text:           text,
+			UserID:         event.User.IDStr,
+			Username:       username,
+			URL:            buildTweetURL(username, tweetID),
+			MediaURLs:      mediaURLs,
+			QuotedTweetID:  quotedTweetID,
+			QuotedUserID:   quotedUserID,
+			QuotedUsername: quotedUsername,
 		})
 	}
 
 	return tweets, nil
+}
+
+func quotedTweet(event tweetObject) (tweetID, userID, username string) {
+	if event.QuotedStatusIDStr != "" {
+		tweetID = event.QuotedStatusIDStr
+	}
+	if event.QuotedStatus != nil {
+		if tweetID == "" {
+			tweetID = event.QuotedStatus.IDStr
+		}
+		userID = event.QuotedStatus.User.IDStr
+		username = event.QuotedStatus.User.ScreenName
+	}
+	return tweetID, userID, username
+}
+
+func tweetQuoteSameAuthor(tweet IncomingTweet) bool {
+	if tweet.UserID != "" && tweet.QuotedUserID != "" {
+		return tweet.UserID == tweet.QuotedUserID
+	}
+	if tweet.Username != "" && tweet.QuotedUsername != "" {
+		return tweet.Username == tweet.QuotedUsername
+	}
+	return false
+}
+
+func resolveMisskeyNoteIDForTweet(crossPostTracker *tracker.CrossPostTracker, tweetID string) (string, bool) {
+	record, ok := crossPostTracker.FindByTweetID(tweetID)
+	if !ok || record.MisskeyNoteID == "" {
+		return "", false
+	}
+	return record.MisskeyNoteID, true
 }
 
 func tweetText(event tweetObject) string {

--- a/internal/handler/tweet2note_test.go
+++ b/internal/handler/tweet2note_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Soli0222/note-tweet-connector/internal/metrics"
+	"github.com/Soli0222/note-tweet-connector/internal/misskey"
 	"github.com/Soli0222/note-tweet-connector/internal/tracker"
 )
 
@@ -243,6 +244,45 @@ func TestParseAccountActivityPayload(t *testing.T) {
 			},
 		},
 		{
+			name: "extract quote tweet metadata",
+			payload: `{
+				"for_user_id": "111",
+				"tweet_create_events": [
+					{
+						"id_str": "123456789",
+						"text": "quote text https://t.co/source",
+						"user": {
+							"id_str": "111",
+							"screen_name": "dummy_user"
+						},
+						"quoted_status_id_str": "987654321",
+						"quoted_status": {
+							"id_str": "987654321",
+							"text": "source text",
+							"user": {
+								"id_str": "111",
+								"screen_name": "dummy_user"
+							}
+						}
+					}
+				]
+			}`,
+			check: func(t *testing.T, tweets []IncomingTweet) {
+				if len(tweets) != 1 {
+					t.Fatalf("expected 1 tweet, got %d", len(tweets))
+				}
+				if tweets[0].QuotedTweetID != "987654321" {
+					t.Fatalf("QuotedTweetID = %q, want 987654321", tweets[0].QuotedTweetID)
+				}
+				if tweets[0].QuotedUserID != "111" {
+					t.Fatalf("QuotedUserID = %q, want 111", tweets[0].QuotedUserID)
+				}
+				if tweets[0].QuotedUsername != "dummy_user" {
+					t.Fatalf("QuotedUsername = %q, want dummy_user", tweets[0].QuotedUsername)
+				}
+			},
+		},
+		{
 			name:    "invalid JSON",
 			payload: `{invalid json}`,
 			wantErr: true,
@@ -280,10 +320,10 @@ func TestHandleIncomingTweet_WithMedia(t *testing.T) {
 	t.Setenv("MISSKEY_HOST", "misskey.example")
 	t.Setenv("MISSKEY_TOKEN", "test-token")
 
-	oldCreate := createMisskeyNoteWithFiles
+	oldCreate := createMisskeyNoteWithOptions
 	oldUpload := uploadMisskeyDriveFileFromURL
 	defer func() {
-		createMisskeyNoteWithFiles = oldCreate
+		createMisskeyNoteWithOptions = oldCreate
 		uploadMisskeyDriveFileFromURL = oldUpload
 	}()
 
@@ -298,12 +338,12 @@ func TestHandleIncomingTweet_WithMedia(t *testing.T) {
 
 	var gotText string
 	var gotFileIDs []string
-	createMisskeyNoteWithFiles = func(ctx context.Context, host, token, text string, fileIDs []string) (string, error) {
+	createMisskeyNoteWithOptions = func(ctx context.Context, host, token string, options misskey.CreateNoteOptions) (string, error) {
 		if host != "misskey.example" || token != "test-token" {
 			t.Fatalf("unexpected create auth host=%q token=%q", host, token)
 		}
-		gotText = text
-		gotFileIDs = append([]string(nil), fileIDs...)
+		gotText = options.Text
+		gotFileIDs = append([]string(nil), options.FileIDs...)
 		return "note-123", nil
 	}
 
@@ -333,6 +373,91 @@ func TestHandleIncomingTweet_WithMedia(t *testing.T) {
 	}
 	if !crossPostTracker.HasMisskeyNote("note-123") {
 		t.Fatal("note ID was not recorded")
+	}
+}
+
+func TestHandleIncomingTweet_QuoteTweetUsesTrackerNoteID(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	crossPostTracker.RememberMisskeyToTweet("source-note", "source-tweet")
+	m := metrics.NewNoop()
+
+	t.Setenv("MISSKEY_HOST", "misskey.example")
+	t.Setenv("MISSKEY_TOKEN", "test-token")
+
+	oldCreate := createMisskeyNoteWithOptions
+	defer func() { createMisskeyNoteWithOptions = oldCreate }()
+
+	var gotOptions misskey.CreateNoteOptions
+	createMisskeyNoteWithOptions = func(ctx context.Context, host, token string, options misskey.CreateNoteOptions) (string, error) {
+		if host != "misskey.example" || token != "test-token" {
+			t.Fatalf("unexpected create auth host=%q token=%q", host, token)
+		}
+		gotOptions = options
+		return "quote-note", nil
+	}
+
+	tweet := IncomingTweet{
+		ID:             "quote-tweet",
+		Text:           "my quote text https://t.co/source",
+		UserID:         "user-1",
+		Username:       "dummy_user",
+		URL:            "https://twitter.com/dummy_user/status/quote-tweet",
+		QuotedTweetID:  "source-tweet",
+		QuotedUserID:   "user-1",
+		QuotedUsername: "dummy_user",
+	}
+
+	if err := HandleIncomingTweet(ctx, tweet, crossPostTracker, m); err != nil {
+		t.Fatalf("HandleIncomingTweet() error = %v", err)
+	}
+	if gotOptions.Text != tweet.Text {
+		t.Fatalf("Text = %q, want %q", gotOptions.Text, tweet.Text)
+	}
+	if gotOptions.RenoteID != "source-note" {
+		t.Fatalf("RenoteID = %q, want source-note", gotOptions.RenoteID)
+	}
+	if !crossPostTracker.HasTweet("quote-tweet") || !crossPostTracker.HasMisskeyNote("quote-note") {
+		t.Fatal("quote cross-post IDs were not recorded")
+	}
+}
+
+func TestHandleIncomingTweet_QuoteTweetFallsBackWhenTrackerMiss(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	m := metrics.NewNoop()
+
+	t.Setenv("MISSKEY_HOST", "misskey.example")
+	t.Setenv("MISSKEY_TOKEN", "test-token")
+
+	oldCreate := createMisskeyNoteWithOptions
+	defer func() { createMisskeyNoteWithOptions = oldCreate }()
+
+	var gotOptions misskey.CreateNoteOptions
+	createMisskeyNoteWithOptions = func(ctx context.Context, host, token string, options misskey.CreateNoteOptions) (string, error) {
+		gotOptions = options
+		return "fallback-note", nil
+	}
+
+	tweet := IncomingTweet{
+		ID:             "quote-tweet",
+		Text:           "my quote text https://t.co/source",
+		UserID:         "user-1",
+		Username:       "dummy_user",
+		URL:            "https://twitter.com/dummy_user/status/quote-tweet",
+		QuotedTweetID:  "missing-source-tweet",
+		QuotedUserID:   "user-1",
+		QuotedUsername: "dummy_user",
+	}
+
+	if err := HandleIncomingTweet(ctx, tweet, crossPostTracker, m); err != nil {
+		t.Fatalf("HandleIncomingTweet() error = %v", err)
+	}
+	if gotOptions.RenoteID != "" {
+		t.Fatalf("RenoteID = %q, want empty fallback", gotOptions.RenoteID)
+	}
+	if gotOptions.Text != tweet.Text {
+		t.Fatalf("Text = %q, want %q", gotOptions.Text, tweet.Text)
 	}
 }
 
@@ -402,10 +527,10 @@ func TestTweet2NoteHandler_SkipsMissingTweetID(t *testing.T) {
 	t.Setenv("MISSKEY_HOST", "misskey.example")
 	t.Setenv("MISSKEY_TOKEN", "test-token")
 
-	oldCreate := createMisskeyNoteWithFiles
-	defer func() { createMisskeyNoteWithFiles = oldCreate }()
-	createMisskeyNoteWithFiles = func(ctx context.Context, host, token, text string, fileIDs []string) (string, error) {
-		t.Fatal("CreateNoteWithFiles should not be called when tweet ID is missing")
+	oldCreate := createMisskeyNoteWithOptions
+	defer func() { createMisskeyNoteWithOptions = oldCreate }()
+	createMisskeyNoteWithOptions = func(ctx context.Context, host, token string, options misskey.CreateNoteOptions) (string, error) {
+		t.Fatal("CreateNoteWithOptions should not be called when tweet ID is missing")
 		return "", nil
 	}
 

--- a/internal/misskey/client.go
+++ b/internal/misskey/client.go
@@ -21,21 +21,34 @@ var httpClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
+type CreateNoteOptions struct {
+	Text     string
+	FileIDs  []string
+	RenoteID string
+}
+
 // CreateNote creates a new note on Misskey
 func CreateNote(ctx context.Context, host, token, text string) (string, error) {
-	return CreateNoteWithFiles(ctx, host, token, text, nil)
+	return CreateNoteWithOptions(ctx, host, token, CreateNoteOptions{Text: text})
 }
 
 // CreateNoteWithFiles creates a new note on Misskey with optional file attachments.
 func CreateNoteWithFiles(ctx context.Context, host, token, text string, fileIDs []string) (string, error) {
+	return CreateNoteWithOptions(ctx, host, token, CreateNoteOptions{Text: text, FileIDs: fileIDs})
+}
+
+func CreateNoteWithOptions(ctx context.Context, host, token string, options CreateNoteOptions) (string, error) {
 	endpoint := "https://" + host + "/api/notes/create"
 
 	jsonData := map[string]interface{}{}
-	if text != "" {
-		jsonData["text"] = text
+	if options.Text != "" {
+		jsonData["text"] = options.Text
 	}
-	if len(fileIDs) > 0 {
-		jsonData["fileIds"] = fileIDs
+	if len(options.FileIDs) > 0 {
+		jsonData["fileIds"] = options.FileIDs
+	}
+	if options.RenoteID != "" {
+		jsonData["renoteId"] = options.RenoteID
 	}
 
 	jsonBytes, err := json.Marshal(jsonData)

--- a/internal/misskey/client_test.go
+++ b/internal/misskey/client_test.go
@@ -54,6 +54,48 @@ func TestCreateNoteWithFilesUsesBearerAuth(t *testing.T) {
 	}
 }
 
+func TestCreateNoteWithOptionsIncludesRenoteID(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/notes/create" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"createdNote":{"id":"note-quote"}}`))
+	}))
+	defer server.Close()
+
+	oldClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = oldClient }()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	noteID, err := CreateNoteWithOptions(context.Background(), host, "test-token", CreateNoteOptions{
+		Text:     "quote text",
+		FileIDs:  []string{"file-1"},
+		RenoteID: "source-note",
+	})
+	if err != nil {
+		t.Fatalf("CreateNoteWithOptions() error = %v", err)
+	}
+	if noteID != "note-quote" {
+		t.Fatalf("noteID = %q, want note-quote", noteID)
+	}
+	if gotBody["text"] != "quote text" {
+		t.Fatalf("text = %#v", gotBody["text"])
+	}
+	if gotBody["renoteId"] != "source-note" {
+		t.Fatalf("renoteId = %#v, want source-note", gotBody["renoteId"])
+	}
+	fileIDs, ok := gotBody["fileIds"].([]interface{})
+	if !ok || len(fileIDs) != 1 || fileIDs[0] != "file-1" {
+		t.Fatalf("fileIds = %#v", gotBody["fileIds"])
+	}
+}
+
 func TestUploadDriveFileFromURL(t *testing.T) {
 	var gotAuth string
 	var gotFile string

--- a/internal/twitter/client.go
+++ b/internal/twitter/client.go
@@ -48,6 +48,12 @@ type ProcessingInfo struct {
 	} `json:"error"`
 }
 
+type PostOptions struct {
+	Text         string
+	MediaURLs    []string
+	QuoteTweetID string
+}
+
 // validateMediaURL validates that the media URL is from an allowed host
 func validateMediaURL(fileURL string) error {
 	parsed, err := url.Parse(fileURL)
@@ -97,11 +103,15 @@ func loadTwitterUserAccessToken() (string, error) {
 
 // Post posts a tweet via Twitter API.
 func Post(ctx context.Context, text string) (string, error) {
-	return PostWithMedia(ctx, text, nil)
+	return PostWithOptions(ctx, PostOptions{Text: text})
 }
 
 // PostWithMedia posts a tweet with media attachments via Twitter API
 func PostWithMedia(ctx context.Context, text string, fileURLs []string) (string, error) {
+	return PostWithOptions(ctx, PostOptions{Text: text, MediaURLs: fileURLs})
+}
+
+func PostWithOptions(ctx context.Context, options PostOptions) (string, error) {
 	ak, aks, at, ats, err := loadTwitterEnv()
 	if err != nil {
 		slog.Error("Error loading Twitter API keys", slog.Any("error", err))
@@ -112,30 +122,38 @@ func PostWithMedia(ctx context.Context, text string, fileURLs []string) (string,
 	token := oauth1.NewToken(at, ats)
 	oauthClient := config.Client(ctx, token)
 
-	limit := len(fileURLs)
+	limit := len(options.MediaURLs)
 	if limit > 4 {
 		limit = 4
 	}
 
 	var mediaIDs []string
 	for i := 0; i < limit; i++ {
-		mediaID, err := uploadMediaFromURL(ctx, fileURLs[i])
+		mediaID, err := uploadMediaFromURL(ctx, options.MediaURLs[i])
 		if err != nil {
 			return "", err
 		}
 		mediaIDs = append(mediaIDs, mediaID)
 	}
 
-	return postTweet(ctx, oauthClient, text, mediaIDs)
+	return postTweet(ctx, oauthClient, options.Text, mediaIDs, options.QuoteTweetID)
 }
 
-func postTweet(ctx context.Context, oauthClient *http.Client, text string, mediaIDs []string) (string, error) {
+func tweetBody(text string, mediaIDs []string, quoteTweetID string) map[string]interface{} {
 	tweetBodyMap := map[string]interface{}{"text": text}
 	if len(mediaIDs) > 0 {
 		tweetBodyMap["media"] = map[string]interface{}{
 			"media_ids": mediaIDs,
 		}
 	}
+	if quoteTweetID != "" {
+		tweetBodyMap["quote_tweet_id"] = quoteTweetID
+	}
+	return tweetBodyMap
+}
+
+func postTweet(ctx context.Context, oauthClient *http.Client, text string, mediaIDs []string, quoteTweetID string) (string, error) {
+	tweetBodyMap := tweetBody(text, mediaIDs, quoteTweetID)
 	tweetBody, err := json.Marshal(tweetBodyMap)
 	if err != nil {
 		slog.Error("Error marshaling tweet data", slog.Any("error", err))

--- a/internal/twitter/client_test.go
+++ b/internal/twitter/client_test.go
@@ -1,6 +1,23 @@
 package twitter
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTweetBodyIncludesQuoteTweetID(t *testing.T) {
+	got := tweetBody("hello", []string{"media-1"}, "tweet-quote")
+	want := map[string]interface{}{
+		"text": "hello",
+		"media": map[string]interface{}{
+			"media_ids": []string{"media-1"},
+		},
+		"quote_tweet_id": "tweet-quote",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tweetBody() = %#v, want %#v", got, want)
+	}
+}
 
 func TestMediaCategoryForType(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
- Note2TweetHandlerで引用リノートのIDをトラッカーから解決するロジックを追加
- 引用リノートの著者が一致しない場合のフォールバック処理を追加
- テストケースを追加して引用リノートの動作を確認
- Misskeyノート作成時にリノートIDをオプションとして渡すように変更
- Twitter APIで引用ツイートIDを含むようにtweetBody関数を修正