### PR TITLE
feat(docker): Dockerfileで非rootユーザーを使用するように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ WORKDIR /app
 
 COPY --from=builder /app/note-tweet-connector .
 
+RUN addgroup -S app && \
+    adduser -S -D -H -u 10001 -G app app && \
+    mkdir -p /app/data && \
+    chown -R app:app /app
+
+USER app
+
 EXPOSE 8080 9090
 
 ENTRYPOINT ["./note-tweet-connector"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ docker compose up -d
 
 CrossPostTrackerのsqlite DBはコンテナ内の`/app/data/tracker.sqlite`に作成されます。`compose.yaml`では`./data:/app/data`をマウントしているため、コンテナを再作成してもTrackerの対応関係は保持されます。
 
+コンテナは非rootユーザー（UID `10001`）で実行されます。bind mountする`./data`は、このUIDから書き込める権限にしてください。
+
 ## Kubernetes
 
 Helm Chartは https://github.com/Soli0222/helm-charts で公開されています。

--- a/cmd/note-tweet-connector/main.go
+++ b/cmd/note-tweet-connector/main.go
@@ -311,7 +311,7 @@ func twitterHMAC(message []byte, secret string) (string, error) {
 
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte("Webhook Test Server is healthy\nVersion: " + version)); err != nil {
+	if _, err := w.Write([]byte("ok\n")); err != nil {
 		slog.Error("Failed to write response", slog.Any("error", err))
 	}
 }


### PR DESCRIPTION
- Dockerfileに非rootユーザー（UID `10001`）を追加し、アプリケーションをそのユーザーで実行するように設定した。
- README.mdにコンテナが非rootユーザーで実行されることを明記した。
- healthzHandlerのレスポンスを簡略化し、"ok"を返すように変更した。