### PR TITLE
feat(log): Twitter webhookの受信時にログを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ curl --request GET \
 
 - `POST /twitter/webhook`にTwitter Account Activity payloadを受け付けます。
 - `x-twitter-webhooks-signature`を`-twitter-webhook-consumer-secret`で検証します。
+- Twitter webhookのPOSTを受信した時点でログを出し、転送対象の`tweet_create_events`がないpayloadもログと`tweet2note_skipped_total{reason="no_eligible_tweets"}`で記録します。
 - CrossPostTrackerに登録済みのtweetはスキップします。
 - `RN [at]`で始まるtweetは転送ループ抑止のためスキップします。
 - `RT @`で始まるtweetは元tweet URLを本文末尾に追記します。

--- a/cmd/note-tweet-connector/main.go
+++ b/cmd/note-tweet-connector/main.go
@@ -257,6 +257,7 @@ func (s *server) twitterWebhookHandler(w http.ResponseWriter, r *http.Request) {
 			s.metrics.WebhookRequestErrors.WithLabelValues("twitter", "read_body").Inc()
 			return
 		}
+		slog.Info("Received Twitter webhook request", slog.Int("body_size", len(body)))
 
 		signature := r.Header.Get("x-twitter-webhooks-signature")
 		if ok, err := verifyTwitterSignature(body, signature, s.twitterSecret); err != nil || !ok {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/internal/handler/tweet2note.go
+++ b/internal/handler/tweet2note.go
@@ -92,6 +92,11 @@ func Tweet2NoteHandlerWithConfig(ctx context.Context, cfg Config, data []byte, c
 		m.Tweet2NoteErrors.Inc()
 		return err
 	}
+	if len(tweets) == 0 {
+		slog.Warn("No eligible tweet_create_events in Twitter webhook payload")
+		m.Tweet2NoteSkipped.WithLabelValues("no_eligible_tweets").Inc()
+		return nil
+	}
 
 	for _, tweet := range tweets {
 		if err := HandleIncomingTweetWithConfig(ctx, cfg, tweet, crossPostTracker, m); err != nil {

--- a/internal/handler/tweet2note_test.go
+++ b/internal/handler/tweet2note_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Soli0222/note-tweet-connector/internal/metrics"
 	"github.com/Soli0222/note-tweet-connector/internal/misskey"
 	"github.com/Soli0222/note-tweet-connector/internal/tracker"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func testHandlerConfig() Config {
@@ -525,6 +526,25 @@ func TestTweet2NoteHandler_KnownCrossPostDetection(t *testing.T) {
 	err := Tweet2NoteHandlerWithConfig(ctx, testHandlerConfig(), []byte(payload), crossPostTracker, m)
 	if err != nil {
 		t.Errorf("Tweet2NoteHandler() should not return error for known cross-post, got %v", err)
+	}
+}
+
+func TestTweet2NoteHandler_NoEligibleTweets(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	m := metrics.NewNoop()
+
+	payload := `{
+		"for_user_id": "111",
+		"tweet_create_events": []
+	}`
+
+	err := Tweet2NoteHandlerWithConfig(ctx, testHandlerConfig(), []byte(payload), crossPostTracker, m)
+	if err != nil {
+		t.Fatalf("Tweet2NoteHandler() error = %v", err)
+	}
+	if got := testutil.ToFloat64(m.Tweet2NoteSkipped.WithLabelValues("no_eligible_tweets")); got != 1 {
+		t.Fatalf("no_eligible_tweets skipped metric = %v, want 1", got)
 	}
 }
 


### PR DESCRIPTION
- Twitter webhookのPOSTを受信した際に、ログを出力するように変更し、転送対象の`tweet_create_events`がないpayloadも記録するようにした。
- `Tweet2NoteHandlerWithConfig`関数において、該当するtweetがない場合に警告ログを出力するようにした。
- `go.mod`に新しい依存関係を追加した。
- 新しいファイル`tmp.md`を追加し、IFTTT関連の実装についての調査結果を記述した。