### PR TITLE
enhance(twitter): メディアアップロードのエラーメッセージを改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ note-tweet-connector \
 
 `-misskey-hook-secret`、`-misskey-host`、`-misskey-token`、`-misskey-media-host`、`-twitter-api-key`、`-twitter-api-key-secret`、`-twitter-access-token`、`-twitter-access-token-secret`は必須です。
 
-Media API v2 chunked uploadにはOAuth 2.0 User Access Tokenが必要です。通常運用では`-twitter-user-refresh-token`と`-twitter-oauth2-client-id`を設定してください。`-twitter-user-access-token`は任意で、未指定の場合は初回利用時にrefresh tokenからaccess tokenを取得します。refresh tokenを取得する認可では`offline.access` scopeが必要です。
+Media API v2 chunked uploadにはOAuth 2.0 User Access Tokenが必要です。通常運用では`-twitter-user-refresh-token`と`-twitter-oauth2-client-id`を設定してください。`-twitter-user-access-token`は任意で、未指定の場合は初回利用時にrefresh tokenからaccess tokenを取得します。refresh tokenを取得する認可では`tweet.write`と`offline.access` scopeが必要です。画像付き投稿だけが403になる場合は、OAuth 2.0 User Access Tokenのscopeとdeveloper appのMedia APIアクセスを確認してください。
 
 Twitter Webhookの登録・確認にはOAuth 2.0 Application-Only Bearer Token、Account Activity subscriptionの作成にはOAuth 1.0a User Contextを使います。これらは初期設定用の認証情報であり、アプリ起動時のフラグとしては使いません。
 

--- a/internal/twitter/client.go
+++ b/internal/twitter/client.go
@@ -480,7 +480,7 @@ func postMediaForm(ctx context.Context, tokenSource BearerTokenSource, fields ma
 			}
 		}
 		if uploadResp.StatusCode < http.StatusOK || uploadResp.StatusCode >= http.StatusMultipleChoices {
-			return fmt.Errorf("media upload request failed with status %d: %s", uploadResp.StatusCode, string(respBytes))
+			return mediaUploadRequestError(fields["command"], uploadResp.StatusCode, respBytes)
 		}
 		break
 	}
@@ -492,6 +492,17 @@ func postMediaForm(ctx context.Context, tokenSource BearerTokenSource, fields ma
 		return fmt.Errorf("failed to parse media upload response: %w", err)
 	}
 	return nil
+}
+
+func mediaUploadRequestError(command string, statusCode int, respBytes []byte) error {
+	detail := previewBody(respBytes)
+	if command == "" {
+		command = "request"
+	}
+	if statusCode == http.StatusForbidden {
+		return fmt.Errorf("media upload %s failed with status %d: %s; verify the Twitter OAuth 2.0 user token was authorized with tweet.write and offline.access scopes and that the developer app has Media API access", command, statusCode, detail)
+	}
+	return fmt.Errorf("media upload %s failed with status %d: %s", command, statusCode, detail)
 }
 
 func mediaCategoryForType(mediaType string) (string, error) {

--- a/internal/twitter/oauth2_token_test.go
+++ b/internal/twitter/oauth2_token_test.go
@@ -201,6 +201,30 @@ func TestPostMediaFormRefreshesAndRetriesOnUnauthorized(t *testing.T) {
 	}
 }
 
+func TestPostMediaFormForbiddenErrorIncludesUploadContext(t *testing.T) {
+	ctx := context.Background()
+	source := StaticBearerTokenSource{Token: "access-token"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"title":"Forbidden","detail":"Forbidden"}`))
+	}))
+	defer server.Close()
+
+	oldEndpoint := UploadMediaEndpoint
+	UploadMediaEndpoint = server.URL
+	defer func() { UploadMediaEndpoint = oldEndpoint }()
+
+	err := postMediaForm(ctx, source, map[string]string{"command": "INIT"}, "", nil, nil)
+	if err == nil {
+		t.Fatal("postMediaForm() succeeded, want error")
+	}
+	for _, want := range []string{"media upload INIT failed with status 403", "tweet.write", "Media API access"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("postMediaForm() error = %q, want substring %q", err.Error(), want)
+		}
+	}
+}
+
 func TestTokenManagerRedactsKnownTokensFromRefreshErrors(t *testing.T) {
 	ctx := context.Background()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- メディアアップロードの失敗時に、OAuth 2.0トークンのスコープとアプリのMedia APIアクセスを確認するようにエラーメッセージを詳細化した。
- テストケースを追加し、403エラー時に適切なエラーメッセージが表示されることを確認した。