### PR TITLE
feat(twitter): メディアアップロードの処理を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ note-tweet-connector \
 
 `-misskey-hook-secret`、`-misskey-host`、`-misskey-token`、`-misskey-media-host`、`-twitter-api-key`、`-twitter-api-key-secret`、`-twitter-access-token`、`-twitter-access-token-secret`は必須です。
 
-Media API v2 chunked uploadにはOAuth 2.0 User Access Tokenが必要です。通常運用では`-twitter-user-refresh-token`と`-twitter-oauth2-client-id`を設定してください。`-twitter-user-access-token`は任意で、未指定の場合は初回利用時にrefresh tokenからaccess tokenを取得します。refresh tokenを取得する認可では`tweet.write`と`offline.access` scopeが必要です。画像付き投稿だけが403になる場合は、OAuth 2.0 User Access Tokenのscopeとdeveloper appのMedia APIアクセスを確認してください。
+Media API v2 uploadにはOAuth 2.0 User Access Tokenが必要です。通常運用では`-twitter-user-refresh-token`と`-twitter-oauth2-client-id`を設定してください。`-twitter-user-access-token`は任意で、未指定の場合は初回利用時にrefresh tokenからaccess tokenを取得します。refresh tokenを取得する認可では`tweet.write`と`offline.access` scopeが必要です。5MB以下の通常画像は単発uploadを使い、GIFや大きいメディアはchunked uploadを使います。画像付き投稿だけが403になる場合は、OAuth 2.0 User Access Tokenのscopeとdeveloper appのMedia APIアクセスを確認してください。
 
 Twitter Webhookの登録・確認にはOAuth 2.0 Application-Only Bearer Token、Account Activity subscriptionの作成にはOAuth 1.0a User Contextを使います。これらは初期設定用の認証情報であり、アプリ起動時のフラグとしては使いません。
 

--- a/internal/twitter/client.go
+++ b/internal/twitter/client.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	ManageTweetEndpoint = "https://api.twitter.com/2/tweets"
-	mediaChunkSize      = 4 * 1024 * 1024
-	maxMediaStatusPolls = 30
+	ManageTweetEndpoint       = "https://api.twitter.com/2/tweets"
+	mediaChunkSize            = 4 * 1024 * 1024
+	maxSimpleImageUploadBytes = 5 * 1024 * 1024
+	maxMediaStatusPolls       = 30
 )
 
 var UploadMediaEndpoint = "https://api.x.com/2/media/upload"
@@ -271,6 +272,10 @@ func uploadMediaFromURL(ctx context.Context, cfg Config, fileURL string) (string
 		return "", err
 	}
 
+	if shouldUseSimpleMediaUpload(mediaType, len(mediaBytes)) {
+		return simpleMediaUpload(ctx, tokenSource, mediaType, mediaCategory, mediaBytes)
+	}
+
 	mediaID, err := initMediaUpload(ctx, tokenSource, mediaType, mediaCategory, len(mediaBytes))
 	if err != nil {
 		return "", err
@@ -291,6 +296,28 @@ func uploadMediaFromURL(ctx context.Context, cfg Config, fileURL string) (string
 	}
 
 	return mediaID, nil
+}
+
+func shouldUseSimpleMediaUpload(mediaType string, totalBytes int) bool {
+	return strings.HasPrefix(mediaType, "image/") &&
+		!strings.HasPrefix(mediaType, "image/gif") &&
+		totalBytes <= maxSimpleImageUploadBytes
+}
+
+func simpleMediaUpload(ctx context.Context, tokenSource BearerTokenSource, mediaType, mediaCategory string, mediaBytes []byte) (string, error) {
+	fields := map[string]string{
+		"media_type":     mediaType,
+		"media_category": mediaCategory,
+	}
+
+	var uploadResponse UploadMediaResponse
+	if err := postMediaForm(ctx, tokenSource, fields, "media", mediaBytes, &uploadResponse); err != nil {
+		return "", err
+	}
+	if uploadResponse.Data.ID == "" {
+		return "", fmt.Errorf("media upload response did not include data.id")
+	}
+	return uploadResponse.Data.ID, nil
 }
 
 func initMediaUpload(ctx context.Context, tokenSource BearerTokenSource, mediaType, mediaCategory string, totalBytes int) (string, error) {

--- a/internal/twitter/client_test.go
+++ b/internal/twitter/client_test.go
@@ -1,7 +1,12 @@
 package twitter
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -73,5 +78,81 @@ func TestValidateMediaURL(t *testing.T) {
 	}
 	if err := validateMediaURL("https://other.example/image.png", "media.example"); err == nil {
 		t.Fatal("validateMediaURL() expected host error")
+	}
+}
+
+func TestUploadMediaFromURLUsesSimpleUploadForImage(t *testing.T) {
+	ctx := context.Background()
+	var uploadCalled bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/image.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("png-data"))
+		case "/2/media/upload":
+			uploadCalled = true
+			if got := r.Header.Get("Authorization"); got != "Bearer token-1" {
+				t.Fatalf("Authorization = %q, want Bearer token-1", got)
+			}
+			if err := r.ParseMultipartForm(1024); err != nil {
+				t.Fatalf("ParseMultipartForm() error = %v", err)
+			}
+			if command := r.FormValue("command"); command != "" {
+				t.Fatalf("command = %q, want empty simple upload", command)
+			}
+			if mediaType := r.FormValue("media_type"); mediaType != "image/png" {
+				t.Fatalf("media_type = %q, want image/png", mediaType)
+			}
+			if mediaCategory := r.FormValue("media_category"); mediaCategory != "tweet_image" {
+				t.Fatalf("media_category = %q, want tweet_image", mediaCategory)
+			}
+			if _, _, err := r.FormFile("media"); err != nil {
+				t.Fatalf("FormFile(media) error = %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"id":"media-1"}}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	oldClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = oldClient }()
+
+	oldEndpoint := UploadMediaEndpoint
+	UploadMediaEndpoint = server.URL + "/2/media/upload"
+	defer func() { UploadMediaEndpoint = oldEndpoint }()
+
+	mediaURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	mediaID, err := uploadMediaFromURL(ctx, Config{
+		BearerTokenSource: StaticBearerTokenSource{Token: "token-1"},
+		MisskeyMediaHost:  mediaURL.Host,
+	}, server.URL+"/image.png")
+	if err != nil {
+		t.Fatalf("uploadMediaFromURL() error = %v", err)
+	}
+	if mediaID != "media-1" {
+		t.Fatalf("mediaID = %q, want media-1", mediaID)
+	}
+	if !uploadCalled {
+		t.Fatal("upload endpoint was not called")
+	}
+}
+
+func TestMediaUploadForbiddenErrorIncludesUploadContext(t *testing.T) {
+	err := mediaUploadRequestError("INIT", http.StatusForbidden, []byte(`{"title":"Forbidden"}`))
+	if err == nil {
+		t.Fatal("mediaUploadRequestError() returned nil")
+	}
+	for _, want := range []string{"media upload INIT failed with status 403", "tweet.write", "Media API access"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("mediaUploadRequestError() = %q, want substring %q", err.Error(), want)
+		}
 	}
 }


### PR DESCRIPTION
- README.mdでMedia API v2のアップロード方法を明確化
- client.goにシンプルメディアアップロード機能を追加
- client_test.goにシンプルメディアアップロードのテストを追加