### PR TITLE
feat(note2tweet): リプライノートのスキップ処理を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ twurl -H api.x.com \
 - `User-Agent`に`Misskey-Hooks`を含まないリクエストは拒否します。
 - `X-Misskey-Hook-Secret`が`-misskey-hook-secret`と一致しないリクエストは拒否します。
 - `visibility`が`public`ではないノート、`localOnly`のノート、CrossPostTrackerに登録済みのノートはスキップします。
+- `replyId`または`reply`があるリプライノートはスキップします。
 - `RT @`で始まるノートは転送ループ抑止のためスキップします。
 - CW付きノートはCW、本文長に応じたマスク、元ノートURLをTweet本文にします。
 - 画像ファイルは最大4件までTwitterへアップロードします。取得元URLはHTTPSかつ`-misskey-media-host`と一致する必要があります。
@@ -255,6 +256,7 @@ twurl -H api.x.com \
 - `x-twitter-webhooks-signature`を`-twitter-webhook-consumer-secret`で検証します。
 - Twitter webhookのPOSTを受信した時点でログを出し、転送対象の`tweet_create_events`がないpayloadもログと`tweet2note_skipped_total{reason="no_eligible_tweets"}`で記録します。
 - CrossPostTrackerに登録済みのtweetはスキップします。
+- `in_reply_to_status_id_str`があるリプライtweetはスキップします。
 - `RN [at]`で始まるtweetは転送ループ抑止のためスキップします。
 - `RT @`で始まるtweetは元tweet URLを本文末尾に追記します。
 - photoメディアは最大4件までMisskey Driveへアップロードし、ノートに添付します。取得元URLはHTTPSかつ`-twitter-media-hosts`に含まれる必要があります。

--- a/internal/handler/note2tweet.go
+++ b/internal/handler/note2tweet.go
@@ -31,11 +31,15 @@ type payloadNoteData struct {
 			Cw         string        `json:"cw"`
 			Text       string        `json:"text"`
 			RenoteID   string        `json:"renoteId"`
+			ReplyID    string        `json:"replyId"`
 			User       struct {
 				ID       string `json:"id"`
 				Host     string `json:"host"`
 				Username string `json:"username"`
 			} `json:"user"`
+			Reply struct {
+				ID string `json:"id"`
+			} `json:"reply"`
 			Renote struct {
 				ID     string `json:"id"`
 				UserID string `json:"userId"`
@@ -101,6 +105,14 @@ func Note2TweetHandlerWithConfig(ctx context.Context, cfg Config, data []byte, c
 			slog.String("note_id", noteID),
 			slog.Bool("local_only", payload.Body.Note.LocalOnly))
 		m.Note2TweetSkipped.WithLabelValues("local_only").Inc()
+		return nil
+	}
+
+	if replyID := noteReplyID(payload); replyID != "" {
+		slog.Info("Note is a reply, skipping",
+			slog.String("note_id", noteID),
+			slog.String("reply_id", replyID))
+		m.Note2TweetSkipped.WithLabelValues("reply").Inc()
 		return nil
 	}
 
@@ -237,6 +249,13 @@ func noteRenoteSameAuthor(payload *payloadNoteData) bool {
 		return payload.Body.Note.User.ID == payload.Body.Note.Renote.User.ID
 	}
 	return false
+}
+
+func noteReplyID(payload *payloadNoteData) string {
+	if payload.Body.Note.ReplyID != "" {
+		return payload.Body.Note.ReplyID
+	}
+	return payload.Body.Note.Reply.ID
 }
 
 func resolveTweetIDForMisskeyNote(ctx context.Context, crossPostTracker tracker.CrossPostTracker, noteID string) (string, bool, error) {

--- a/internal/handler/note2tweet_test.go
+++ b/internal/handler/note2tweet_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Soli0222/note-tweet-connector/internal/metrics"
 	"github.com/Soli0222/note-tweet-connector/internal/tracker"
 	"github.com/Soli0222/note-tweet-connector/internal/twitter"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestParseNotePayload(t *testing.T) {
@@ -318,6 +319,88 @@ func TestNote2TweetHandler_KnownCrossPostDetection(t *testing.T) {
 	err := Note2TweetHandler(ctx, []byte(payload), crossPostTracker, m)
 	if err != nil {
 		t.Errorf("Note2TweetHandler() should not return error for known cross-post, got %v", err)
+	}
+}
+
+func TestNote2TweetHandler_SkipsReply(t *testing.T) {
+	ctx := context.Background()
+
+	oldPost := postTweet
+	oldPostWithMedia := postTweetWithMedia
+	oldPostWithOptions := postTweetWithOptions
+	defer func() {
+		postTweet = oldPost
+		postTweetWithMedia = oldPostWithMedia
+		postTweetWithOptions = oldPostWithOptions
+	}()
+
+	postTweet = func(ctx context.Context, text string) (string, error) {
+		t.Fatal("Post should not be called for a reply note")
+		return "", nil
+	}
+	postTweetWithMedia = func(ctx context.Context, text string, fileURLs []string) (string, error) {
+		t.Fatal("PostWithMedia should not be called for a reply note")
+		return "", nil
+	}
+	postTweetWithOptions = func(ctx context.Context, options twitter.PostOptions) (string, error) {
+		t.Fatal("PostWithOptions should not be called for a reply note")
+		return "", nil
+	}
+
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "replyId",
+			payload: `{
+				"body": {
+					"note": {
+						"id": "reply-note-1",
+						"text": "Reply note",
+						"visibility": "public",
+						"localOnly": false,
+						"files": [],
+						"cw": null,
+						"replyId": "source-note"
+					}
+				},
+				"server": "https://misskey.example"
+			}`,
+		},
+		{
+			name: "reply object",
+			payload: `{
+				"body": {
+					"note": {
+						"id": "reply-note-2",
+						"text": "Reply note",
+						"visibility": "public",
+						"localOnly": false,
+						"files": [],
+						"cw": null,
+						"reply": {
+							"id": "source-note"
+						}
+					}
+				},
+				"server": "https://misskey.example"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+			m := metrics.NewNoop()
+
+			if err := Note2TweetHandler(ctx, []byte(tt.payload), crossPostTracker, m); err != nil {
+				t.Fatalf("Note2TweetHandler() error = %v", err)
+			}
+			if got := testutil.ToFloat64(m.Note2TweetSkipped.WithLabelValues("reply")); got != 1 {
+				t.Fatalf("reply skipped metric = %v, want 1", got)
+			}
+		})
 	}
 }
 

--- a/internal/handler/tweet2note.go
+++ b/internal/handler/tweet2note.go
@@ -15,15 +15,16 @@ import (
 )
 
 type IncomingTweet struct {
-	ID             string
-	Text           string
-	UserID         string
-	Username       string
-	URL            string
-	MediaURLs      []string
-	QuotedTweetID  string
-	QuotedUserID   string
-	QuotedUsername string
+	ID               string
+	Text             string
+	UserID           string
+	Username         string
+	URL              string
+	MediaURLs        []string
+	QuotedTweetID    string
+	QuotedUserID     string
+	QuotedUsername   string
+	InReplyToTweetID string
 }
 
 type Config struct {
@@ -40,16 +41,17 @@ type accountActivityPayload struct {
 }
 
 type tweetObject struct {
-	IDStr             string          `json:"id_str"`
-	Text              string          `json:"text"`
-	FullText          string          `json:"full_text"`
-	Truncated         bool            `json:"truncated"`
-	User              twitterUser     `json:"user"`
-	Entities          twitterEntities `json:"entities"`
-	ExtendedEntities  twitterEntities `json:"extended_entities"`
-	ExtendedTweet     extendedTweet   `json:"extended_tweet"`
-	QuotedStatusIDStr string          `json:"quoted_status_id_str"`
-	QuotedStatus      *tweetObject    `json:"quoted_status"`
+	IDStr                string          `json:"id_str"`
+	Text                 string          `json:"text"`
+	FullText             string          `json:"full_text"`
+	Truncated            bool            `json:"truncated"`
+	User                 twitterUser     `json:"user"`
+	Entities             twitterEntities `json:"entities"`
+	ExtendedEntities     twitterEntities `json:"extended_entities"`
+	ExtendedTweet        extendedTweet   `json:"extended_tweet"`
+	QuotedStatusIDStr    string          `json:"quoted_status_id_str"`
+	QuotedStatus         *tweetObject    `json:"quoted_status"`
+	InReplyToStatusIDStr string          `json:"in_reply_to_status_id_str"`
 }
 
 type extendedTweet struct {
@@ -131,6 +133,14 @@ func HandleIncomingTweetWithConfig(ctx context.Context, cfg Config, tweet Incomi
 			slog.String("tweet_id", tweet.ID))
 		m.Tweet2NoteSkipped.WithLabelValues("crosspost").Inc()
 		m.TrackerDuplicatesHit.Inc()
+		return nil
+	}
+
+	if tweet.InReplyToTweetID != "" {
+		slog.Info("Tweet is a reply, skipping",
+			slog.String("tweet_id", tweet.ID),
+			slog.String("in_reply_to_tweet_id", tweet.InReplyToTweetID))
+		m.Tweet2NoteSkipped.WithLabelValues("reply").Inc()
 		return nil
 	}
 
@@ -267,15 +277,16 @@ func parseAccountActivityPayloadWithConfig(data []byte, cfg Config) ([]IncomingT
 		}
 		quotedTweetID, quotedUserID, quotedUsername := quotedTweet(event)
 		tweets = append(tweets, IncomingTweet{
-			ID:             tweetID,
-			Text:           text,
-			UserID:         event.User.IDStr,
-			Username:       username,
-			URL:            buildTweetURL(username, tweetID),
-			MediaURLs:      mediaURLs,
-			QuotedTweetID:  quotedTweetID,
-			QuotedUserID:   quotedUserID,
-			QuotedUsername: quotedUsername,
+			ID:               tweetID,
+			Text:             text,
+			UserID:           event.User.IDStr,
+			Username:         username,
+			URL:              buildTweetURL(username, tweetID),
+			MediaURLs:        mediaURLs,
+			QuotedTweetID:    quotedTweetID,
+			QuotedUserID:     quotedUserID,
+			QuotedUsername:   quotedUsername,
+			InReplyToTweetID: event.InReplyToStatusIDStr,
 		})
 	}
 

--- a/internal/handler/tweet2note_test.go
+++ b/internal/handler/tweet2note_test.go
@@ -293,6 +293,31 @@ func TestParseAccountActivityPayload(t *testing.T) {
 			},
 		},
 		{
+			name: "extract reply metadata",
+			payload: `{
+				"for_user_id": "111",
+				"tweet_create_events": [
+					{
+						"id_str": "123456789",
+						"text": "reply text",
+						"in_reply_to_status_id_str": "987654321",
+						"user": {
+							"id_str": "111",
+							"screen_name": "dummy_user"
+						}
+					}
+				]
+			}`,
+			check: func(t *testing.T, tweets []IncomingTweet) {
+				if len(tweets) != 1 {
+					t.Fatalf("expected 1 tweet, got %d", len(tweets))
+				}
+				if tweets[0].InReplyToTweetID != "987654321" {
+					t.Fatalf("InReplyToTweetID = %q, want 987654321", tweets[0].InReplyToTweetID)
+				}
+			},
+		},
+		{
 			name:    "invalid JSON",
 			payload: `{invalid json}`,
 			wantErr: true,
@@ -526,6 +551,41 @@ func TestTweet2NoteHandler_KnownCrossPostDetection(t *testing.T) {
 	err := Tweet2NoteHandlerWithConfig(ctx, testHandlerConfig(), []byte(payload), crossPostTracker, m)
 	if err != nil {
 		t.Errorf("Tweet2NoteHandler() should not return error for known cross-post, got %v", err)
+	}
+}
+
+func TestTweet2NoteHandler_SkipsReply(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	m := metrics.NewNoop()
+
+	oldCreate := createMisskeyNoteWithOptions
+	defer func() { createMisskeyNoteWithOptions = oldCreate }()
+	createMisskeyNoteWithOptions = func(ctx context.Context, host, token string, options misskey.CreateNoteOptions) (string, error) {
+		t.Fatal("CreateNoteWithOptions should not be called for a reply tweet")
+		return "", nil
+	}
+
+	payload := `{
+		"for_user_id": "111",
+		"tweet_create_events": [
+			{
+				"id_str": "333",
+				"text": "Reply tweet",
+				"in_reply_to_status_id_str": "222",
+				"user": {
+					"id_str": "111",
+					"screen_name": "dummy_user"
+				}
+			}
+		]
+	}`
+
+	if err := Tweet2NoteHandlerWithConfig(ctx, testHandlerConfig(), []byte(payload), crossPostTracker, m); err != nil {
+		t.Fatalf("Tweet2NoteHandler() error = %v", err)
+	}
+	if got := testutil.ToFloat64(m.Tweet2NoteSkipped.WithLabelValues("reply")); got != 1 {
+		t.Fatalf("reply skipped metric = %v, want 1", got)
 	}
 }
 

--- a/tmp.md
+++ b/tmp.md
@@ -1,0 +1,120 @@
+# リプライ転送をスキップする実装方針
+
+## 現状
+
+- Misskey -> Twitter は `internal/handler/note2tweet.go` の `Note2TweetHandlerWithConfig` で処理している。
+- Twitter -> Misskey は `internal/handler/tweet2note.go` の `Tweet2NoteHandlerWithConfig` / `HandleIncomingTweetWithConfig` で処理している。
+- どちらも現在は「公開投稿か」「localOnlyか」「CrossPostTracker登録済みか」「転送ループっぽい本文か」は見ているが、リプライかどうかは見ていない。
+
+## 方針
+
+Misskey側・Twitter側とも、payloadからリプライ元IDを取り込み、投稿処理やメディアアップロードより前にスキップする。
+
+スキップ理由のmetric labelは両方向とも `reply` にそろえる。
+
+## Misskey -> Twitter
+
+1. `internal/handler/note2tweet.go` の `payloadNoteData.Body.Note` にリプライ判定用フィールドを追加する。
+
+```go
+ReplyID string `json:"replyId"`
+Reply   struct {
+    ID string `json:"id"`
+} `json:"reply"`
+```
+
+2. `Note2TweetHandlerWithConfig` で `noteID` の空チェック、CrossPostTrackerチェック、公開範囲チェック、`localOnly` チェックの後あたりに、リプライならスキップする条件を入れる。
+
+```go
+if payload.Body.Note.ReplyID != "" || payload.Body.Note.Reply.ID != "" {
+    slog.Info("Note is a reply, skipping",
+        slog.String("note_id", noteID),
+        slog.String("reply_id", payload.Body.Note.ReplyID))
+    m.Note2TweetSkipped.WithLabelValues("reply").Inc()
+    return nil
+}
+```
+
+3. この位置に置く理由:
+
+- `noteID` が無いpayloadは既存どおり `missing_id` として扱える。
+- 非公開・localOnlyは既存理由のまま記録できる。
+- リプライ本文の整形、画像抽出、Twitter投稿の前に止められる。
+
+## Twitter -> Misskey
+
+1. `internal/handler/tweet2note.go` の `IncomingTweet` にリプライ元IDを追加する。
+
+```go
+InReplyToTweetID string
+```
+
+2. 同じファイルの `tweetObject` に Account Activity payload のリプライ元IDを追加する。
+
+```go
+InReplyToStatusIDStr string `json:"in_reply_to_status_id_str"`
+```
+
+必要ならユーザーIDも後でログ用途に足せる。
+
+```go
+InReplyToUserIDStr string `json:"in_reply_to_user_id_str"`
+```
+
+3. `parseAccountActivityPayloadWithConfig` で `IncomingTweet` を作るときに詰める。
+
+```go
+InReplyToTweetID: event.InReplyToStatusIDStr,
+```
+
+4. `HandleIncomingTweetWithConfig` で `tweet.ID` の空チェック、CrossPostTrackerチェックの後あたりに、リプライならスキップする条件を入れる。
+
+```go
+if tweet.InReplyToTweetID != "" {
+    slog.Info("Tweet is a reply, skipping",
+        slog.String("tweet_id", tweet.ID),
+        slog.String("in_reply_to_tweet_id", tweet.InReplyToTweetID))
+    m.Tweet2NoteSkipped.WithLabelValues("reply").Inc()
+    return nil
+}
+```
+
+5. この位置に置く理由:
+
+- ID欠落と重複は既存理由で扱える。
+- `RT @` や `RN [at]` の本文パターン判定より前に止めても問題ない。
+- Misskey Driveへの画像アップロードやMisskey投稿の前に止められる。
+
+## テスト
+
+最低限、次のテストを追加する。
+
+1. `internal/handler/note2tweet_test.go`
+   - `replyId` がある公開ノートを渡したとき、`postTweet` が呼ばれず `note2tweet_skipped_total{reason="reply"}` が1増えること。
+   - できれば `reply.id` だけがあるpayloadでもスキップされること。
+
+2. `internal/handler/tweet2note_test.go`
+   - `in_reply_to_status_id_str` があるtweetを渡したとき、`createMisskeyNoteWithOptions` が呼ばれず `tweet2note_skipped_total{reason="reply"}` が1増えること。
+   - `parseAccountActivityPayload` が `InReplyToTweetID` を保持すること。
+
+既存テストでは `prometheus/testutil` を使っているので、それに合わせる。
+
+## README更新
+
+`README.md` の動作仕様を更新する。
+
+- MisskeyからTwitter:
+  - `replyId` または `reply` があるノートはスキップします。
+- TwitterからMisskey:
+  - `in_reply_to_status_id_str` があるtweetはスキップします。
+
+このリポジトリの表記ルールに合わせ、サービス名は `Twitter`、投稿は `Tweet` / `tweet` を使う。
+
+## 完了確認
+
+実装後に必ず実行する。
+
+```bash
+go test ./...
+golangci-lint run
+```


### PR DESCRIPTION
- note2tweet.goにリプライ判定用フィールドを追加し、リプライノートをスキップする条件を実装。
- tweet2note.goにリプライ元IDを追加し、リプライツイートをスキップする処理を追加。
- note2tweet_test.goおよびtweet2note_test.goにリプライスキップのテストケースを追加。
- README.mdにリプライスキップの動作仕様を更新。
- tmp.mdにリプライ転送をスキップする実装方針を追加。