### PR TITLE
feat(twitter): Twitter streamのkeep-aliveタイムアウトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ note-tweet-connector \
 | `-twitter-oauth2-redirect-url` | なし | OAuth 2.0 callback URL。Twitter Developer Portalのcallback URLと完全一致させる |
 | `-twitter-token-store-path` | `data/twitter_oauth2_token.json` | 更新済みOAuth 2.0 tokenを保存するJSONファイル |
 | `-twitter-bearer-token` | なし | Twitter Filtered Streamとrule管理に使うApplication-Only Bearer Token |
+| `-twitter-stream-keep-alive-timeout` | `90s` | Twitter streamのデータまたはkeep-aliveが途絶えたと判断するまでの時間 |
 | `-twitter-stream-reconnect-min` | `5s` | Twitter stream再接続backoffの初期値 |
 | `-twitter-stream-reconnect-max` | `5m` | Twitter stream再接続backoffの上限 |
 | `-twitter-username` | なし | stream rule生成とpayloadからユーザー名を取得できない場合に使うTwitterユーザー名 |
@@ -140,6 +141,7 @@ docker compose up -d
 | `TWITTER_OAUTH2_REDIRECT_URL` | はい | Twitter OAuth 2.0 callback URL。例: `https://your-domain.example/twitter/callback` |
 | `TWITTER_TOKEN_STORE_PATH` | いいえ | 更新済みOAuth 2.0 tokenの保存先。未指定時は`data/twitter_oauth2_token.json` |
 | `TWITTER_BEARER_TOKEN` | はい | Twitter Filtered Streamとrule管理に使うApplication-Only Bearer Token |
+| `TWITTER_STREAM_KEEP_ALIVE_TIMEOUT` | いいえ | Twitter stream keep-alive timeout。未指定時は`90s` |
 | `TWITTER_USERNAME` | はい | stream rule生成とfallback用Twitterユーザー名 |
 
 CrossPostTrackerのsqlite DBはコンテナ内の`/app/data/tracker.sqlite`に作成されます。OAuth 2.0 token storeはデフォルトで`/app/data/twitter_oauth2_token.json`に作成されます。`compose.yaml`では`./data:/app/data`をマウントしているため、コンテナを再作成してもTrackerの対応関係と更新済みtokenは保持されます。
@@ -193,7 +195,7 @@ from:${TWITTER_USERNAME} -is:retweet -is:reply
 ### TwitterからMisskey
 
 - Twitter Filtered Streamに永続接続し、受信したpayloadを処理します。
-- 20秒以上streamのデータまたはkeep-aliveが来ない場合は接続を切り、backoff付きで再接続します。
+- `-twitter-stream-keep-alive-timeout`以上streamのデータまたはkeep-aliveが来ない場合は接続を切り、backoff付きで再接続します。
 - 転送対象のtweetがないpayloadはログと`tweet2note_skipped_total{reason="no_eligible_tweets"}`で記録します。
 - CrossPostTrackerに登録済みのtweetはスキップします。
 - `referenced_tweets.type == "replied_to"`があるリプライtweetはスキップします。

--- a/cmd/note-tweet-connector/main.go
+++ b/cmd/note-tweet-connector/main.go
@@ -46,6 +46,7 @@ type Config struct {
 	TwitterOAuth2RedirectURL  string
 	TwitterTokenStorePath     string
 	TwitterBearerToken        string
+	TwitterStreamKeepAlive    time.Duration
 	TwitterStreamReconnectMin time.Duration
 	TwitterStreamReconnectMax time.Duration
 	TwitterUsername           string
@@ -72,6 +73,7 @@ func parseFlags() *Config {
 	flag.StringVar(&cfg.TwitterOAuth2RedirectURL, "twitter-oauth2-redirect-url", "", "Twitter OAuth 2.0 redirect URL")
 	flag.StringVar(&cfg.TwitterTokenStorePath, "twitter-token-store-path", "data/twitter_oauth2_token.json", "Path to JSON file for refreshed Twitter OAuth 2.0 tokens")
 	flag.StringVar(&cfg.TwitterBearerToken, "twitter-bearer-token", "", "Twitter Application-Only Bearer Token for Filtered Stream")
+	flag.DurationVar(&cfg.TwitterStreamKeepAlive, "twitter-stream-keep-alive-timeout", 90*time.Second, "Twitter stream keep-alive timeout")
 	flag.DurationVar(&cfg.TwitterStreamReconnectMin, "twitter-stream-reconnect-min", 5*time.Second, "Minimum Twitter stream reconnect backoff")
 	flag.DurationVar(&cfg.TwitterStreamReconnectMax, "twitter-stream-reconnect-max", 5*time.Minute, "Maximum Twitter stream reconnect backoff")
 	flag.StringVar(&cfg.TwitterUsername, "twitter-username", "", "Fallback Twitter username")
@@ -116,6 +118,9 @@ func (cfg *Config) validate() error {
 	}
 	if cfg.TwitterUsername == "" {
 		return fmt.Errorf("missing required flags: -twitter-username")
+	}
+	if cfg.TwitterStreamKeepAlive <= 0 {
+		return fmt.Errorf("-twitter-stream-keep-alive-timeout must be positive")
 	}
 	if cfg.TwitterStreamReconnectMin <= 0 {
 		return fmt.Errorf("-twitter-stream-reconnect-min must be positive")
@@ -380,6 +385,14 @@ func updateTrackerEntriesMetric(ctx context.Context, crossPostTracker tracker.Cr
 
 func runTwitterStream(ctx context.Context, streamClient *twitter.StreamClient, cfg handler.Config, crossPostTracker tracker.CrossPostTracker, m *metrics.Metrics, reconnectMin, reconnectMax time.Duration) {
 	backoff := reconnectMin
+	onConnect := streamClient.OnConnect
+	streamClient.OnConnect = func() {
+		backoff = reconnectMin
+		if onConnect != nil {
+			onConnect()
+		}
+	}
+
 	for {
 		if ctx.Err() != nil {
 			return
@@ -449,6 +462,10 @@ func twitterStreamReconnectDelay(err error, fallback time.Duration) time.Duratio
 			return delay
 		}
 	}
+	var httpErr *twitter.StreamHTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusServiceUnavailable && strings.Contains(httpErr.Body, "ProvisioningSubscription") {
+		return time.Minute
+	}
 	return fallback
 }
 
@@ -512,6 +529,7 @@ func main() {
 		login:  oauth2Login,
 	})
 	streamClient := twitter.NewStreamClient(twitter.StaticBearerTokenSource{Token: cfg.TwitterBearerToken})
+	streamClient.KeepAliveTimeout = cfg.TwitterStreamKeepAlive
 	streamClient.OnConnect = func() {
 		m.TwitterStreamConnects.WithLabelValues("success").Inc()
 		slog.Info("Connected to Twitter Filtered Stream")

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       - -twitter-oauth2-redirect-url=${TWITTER_OAUTH2_REDIRECT_URL:?TWITTER_OAUTH2_REDIRECT_URL is required}
       - -twitter-token-store-path=${TWITTER_TOKEN_STORE_PATH:-data/twitter_oauth2_token.json}
       - -twitter-bearer-token=${TWITTER_BEARER_TOKEN:?TWITTER_BEARER_TOKEN is required}
+      - -twitter-stream-keep-alive-timeout=${TWITTER_STREAM_KEEP_ALIVE_TIMEOUT:-90s}
       - -twitter-username=${TWITTER_USERNAME:?TWITTER_USERNAME is required}
     ports:
       - "8080:8080"

--- a/internal/twitter/stream.go
+++ b/internal/twitter/stream.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defaultStreamKeepAliveTimeout = 20 * time.Second
+	defaultStreamKeepAliveTimeout = 90 * time.Second
 	defaultStreamRuleTag          = "note-tweet-connector"
 )
 
@@ -35,6 +35,7 @@ type StreamRule struct {
 type StreamClient struct {
 	BearerTokenSource BearerTokenSource
 	HTTPClient        *http.Client
+	StreamHTTPClient  *http.Client
 	StreamEndpoint    string
 	RulesEndpoint     string
 	KeepAliveTimeout  time.Duration
@@ -81,6 +82,7 @@ func NewStreamClient(source BearerTokenSource) *StreamClient {
 	return &StreamClient{
 		BearerTokenSource: source,
 		HTTPClient:        httpClient,
+		StreamHTTPClient:  &http.Client{},
 		StreamEndpoint:    FilteredStreamEndpoint,
 		RulesEndpoint:     FilteredStreamRulesEndpoint,
 		KeepAliveTimeout:  defaultStreamKeepAliveTimeout,
@@ -191,7 +193,7 @@ func (c *StreamClient) Consume(ctx context.Context, handleLine func(context.Cont
 		return err
 	}
 
-	client := c.client()
+	client := c.streamClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
@@ -289,6 +291,13 @@ func (c *StreamClient) client() *http.Client {
 		return c.HTTPClient
 	}
 	return httpClient
+}
+
+func (c *StreamClient) streamClient() *http.Client {
+	if c.StreamHTTPClient != nil {
+		return c.StreamHTTPClient
+	}
+	return c.client()
 }
 
 func (c *StreamClient) rulesEndpoint() string {

--- a/internal/twitter/stream_test.go
+++ b/internal/twitter/stream_test.go
@@ -105,7 +105,7 @@ func TestConsumeReadsStreamLines(t *testing.T) {
 
 	client := NewStreamClient(StaticBearerTokenSource{Token: "token-1"})
 	client.StreamEndpoint = server.URL + "/2/tweets/search/stream"
-	client.HTTPClient = server.Client()
+	client.StreamHTTPClient = server.Client()
 	client.KeepAliveTimeout = time.Second
 
 	var lines [][]byte
@@ -123,5 +123,18 @@ func TestConsumeReadsStreamLines(t *testing.T) {
 		if !strings.Contains(gotQuery, want) {
 			t.Fatalf("query %q does not contain %q", gotQuery, want)
 		}
+	}
+}
+
+func TestNewStreamClientUsesHTTPClientWithoutTimeoutForStream(t *testing.T) {
+	client := NewStreamClient(StaticBearerTokenSource{Token: "token-1"})
+	if client.StreamHTTPClient == nil {
+		t.Fatal("StreamHTTPClient is nil")
+	}
+	if client.StreamHTTPClient.Timeout != 0 {
+		t.Fatalf("StreamHTTPClient.Timeout = %s, want 0", client.StreamHTTPClient.Timeout)
+	}
+	if client.HTTPClient == nil || client.HTTPClient.Timeout == 0 {
+		t.Fatalf("HTTPClient timeout = %v, want non-zero timeout for non-stream requests", client.HTTPClient.Timeout)
 	}
 }


### PR DESCRIPTION
- README.mdにTwitter streamのkeep-aliveタイムアウトの説明を追加
- main.goにTwitterStreamKeepAliveフィールドを追加
- compose.yamlに環境変数TWITTER_STREAM_KEEP_ALIVE_TIMEOUTを追加
- stream.goでデフォルトのkeep-aliveタイムアウトを90秒に変更
- stream.goでStreamHTTPClientを追加
- stream_test.goでStreamHTTPClientのテストを追加