### PR TITLE
feat(twitter): リツイートのURLを参照するように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ helm install note-tweet-connector soli0222/note-tweet-connector -f values.yaml
 デフォルトのruleは次の形式です。
 
 ```text
-from:${TWITTER_USERNAME} -is:retweet -is:reply
+from:${TWITTER_USERNAME} -is:reply
 ```
 
 ## 動作仕様
@@ -200,7 +200,7 @@ from:${TWITTER_USERNAME} -is:retweet -is:reply
 - CrossPostTrackerに登録済みのtweetはスキップします。
 - `referenced_tweets.type == "replied_to"`があるリプライtweetはスキップします。
 - `RN [at]`で始まるtweetは転送ループ抑止のためスキップします。
-- `RT @`で始まるtweetは元tweet URLを本文末尾に追記します。
+- `RT @`で始まるtweetは元tweet URLを本文末尾に追記します。Filtered Stream ruleではretweetを除外しません。
 - photoメディアは最大4件までMisskey Driveへアップロードし、ノートに添付します。取得元URLはHTTPSかつ`-twitter-media-hosts`に含まれる必要があります。
 - 同一作者の引用tweetで、引用元tweet IDに対応するMisskey note IDがTrackerにある場合は、Misskeyのrenoteとして作成します。
 

--- a/internal/handler/tweet2note.go
+++ b/internal/handler/tweet2note.go
@@ -273,13 +273,17 @@ func parseFilteredStreamPayloadWithConfig(data []byte, cfg Config) ([]IncomingTw
 		username = cfg.TwitterUsername
 	}
 	quotedTweetID, quotedUserID, quotedUsername := filteredStreamQuote(payload)
+	tweetURL := buildTweetURL(username, payload.Data.ID)
+	if retweetURL := filteredStreamRetweetURL(payload); retweetURL != "" {
+		tweetURL = retweetURL
+	}
 
 	return []IncomingTweet{{
 		ID:               payload.Data.ID,
 		Text:             text,
 		UserID:           payload.Data.AuthorID,
 		Username:         username,
-		URL:              buildTweetURL(username, payload.Data.ID),
+		URL:              tweetURL,
 		MediaURLs:        mediaURLs,
 		QuotedTweetID:    quotedTweetID,
 		QuotedUserID:     quotedUserID,
@@ -358,6 +362,25 @@ func filteredStreamQuote(payload filteredStreamPayload) (tweetID, userID, userna
 		}
 	}
 	return tweetID, userID, username
+}
+
+func filteredStreamRetweetURL(payload filteredStreamPayload) string {
+	var retweetedTweetID string
+	for _, ref := range payload.Data.ReferencedTweets {
+		if ref.Type == "retweeted" {
+			retweetedTweetID = ref.ID
+			break
+		}
+	}
+	if retweetedTweetID == "" {
+		return ""
+	}
+	for _, tweet := range payload.Includes.Tweets {
+		if tweet.ID == retweetedTweetID {
+			return buildTweetURL(filteredStreamUsername(payload, tweet.AuthorID), retweetedTweetID)
+		}
+	}
+	return ""
 }
 
 func filteredStreamReplyTweetID(tweet filteredStreamTweet) string {

--- a/internal/handler/tweet2note_test.go
+++ b/internal/handler/tweet2note_test.go
@@ -211,6 +211,49 @@ func TestParseFilteredStreamPayload(t *testing.T) {
 			},
 		},
 		{
+			name: "retweet uses referenced tweet URL",
+			payload: `{
+					"data": {
+						"id": "123456789",
+						"text": "RT @other_user: original text",
+						"author_id": "111",
+						"referenced_tweets": [
+							{
+								"type": "retweeted",
+								"id": "987654321"
+							}
+						]
+					},
+					"includes": {
+						"tweets": [
+							{
+								"id": "987654321",
+								"text": "original text",
+								"author_id": "222"
+							}
+						],
+						"users": [
+							{
+								"id": "111",
+								"username": "dummy_user"
+							},
+							{
+								"id": "222",
+								"username": "other_user"
+							}
+						]
+					}
+				}`,
+			check: func(t *testing.T, tweets []IncomingTweet) {
+				if len(tweets) != 1 {
+					t.Fatalf("expected 1 tweet, got %d", len(tweets))
+				}
+				if tweets[0].URL != "https://twitter.com/other_user/status/987654321" {
+					t.Fatalf("URL = %q", tweets[0].URL)
+				}
+			},
+		},
+		{
 			name:    "invalid JSON",
 			payload: `{invalid json}`,
 			wantErr: true,

--- a/internal/twitter/stream.go
+++ b/internal/twitter/stream.go
@@ -71,7 +71,7 @@ func DefaultStreamRule(username string) string {
 	if username == "" {
 		return ""
 	}
-	return "from:" + username + " -is:retweet -is:reply"
+	return "from:" + username + " -is:reply"
 }
 
 func DefaultStreamRuleTag() string {

--- a/internal/twitter/stream_test.go
+++ b/internal/twitter/stream_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDefaultStreamRule(t *testing.T) {
-	if got := DefaultStreamRule("dummy_user"); got != "from:dummy_user -is:retweet -is:reply" {
+	if got := DefaultStreamRule("dummy_user"); got != "from:dummy_user -is:reply" {
 		t.Fatalf("DefaultStreamRule() = %q", got)
 	}
 	if got := DefaultStreamRule(""); got != "" {
@@ -31,7 +31,7 @@ func TestEnsureRuleNoopWhenRuleExists(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("unexpected method %s", r.Method)
 		}
-		_, _ = w.Write([]byte(`{"data":[{"id":"rule-1","value":"from:dummy_user -is:retweet -is:reply","tag":"note-tweet-connector"}]}`))
+		_, _ = w.Write([]byte(`{"data":[{"id":"rule-1","value":"from:dummy_user -is:reply","tag":"note-tweet-connector"}]}`))
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
- DefaultStreamRuleでリツイートを除外しないように修正
- parseFilteredStreamPayloadWithConfigでリツイートのURLを取得する処理を追加
- テストケースを追加し、リツイートのURLが正しく設定されることを確認