### PR TITLE
feat(twitter): リツイートのメディアアップロードをスキップする機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ from:${TWITTER_USERNAME} -is:reply
 - CrossPostTrackerに登録済みのtweetはスキップします。
 - `referenced_tweets.type == "replied_to"`があるリプライtweetはスキップします。
 - `RN [at]`で始まるtweetは転送ループ抑止のためスキップします。
-- `RT @`で始まるtweetは元tweet URLを本文末尾に追記します。Filtered Stream ruleではretweetを除外しません。
-- photoメディアは最大4件までMisskey Driveへアップロードし、ノートに添付します。取得元URLはHTTPSかつ`-twitter-media-hosts`に含まれる必要があります。
+- `RT @`で始まるtweetは元tweet URLを本文末尾に追記します。リツイートの場合、画像はMisskey Driveへアップロードしません。Filtered Stream ruleではretweetを除外しません。
+- 通常のtweetのphotoメディアは最大4件までMisskey Driveへアップロードし、ノートに添付します。取得元URLはHTTPSかつ`-twitter-media-hosts`に含まれる必要があります。
 - 同一作者の引用tweetで、引用元tweet IDに対応するMisskey note IDがTrackerにある場合は、Misskeyのrenoteとして作成します。
 
 ## エンドポイント

--- a/internal/handler/tweet2note.go
+++ b/internal/handler/tweet2note.go
@@ -21,6 +21,7 @@ type IncomingTweet struct {
 	Username         string
 	URL              string
 	MediaURLs        []string
+	IsRetweet        bool
 	QuotedTweetID    string
 	QuotedUserID     string
 	QuotedUsername   string
@@ -198,17 +199,20 @@ func HandleIncomingTweetWithConfig(ctx context.Context, cfg Config, tweet Incomi
 		return fmt.Errorf("misskey token is not configured")
 	}
 
-	fileIDs := make([]string, 0, min(len(tweet.MediaURLs), 4))
-	for i := 0; i < len(tweet.MediaURLs) && i < 4; i++ {
-		fileID, err := uploadMisskeyDriveFileFromURL(ctx, cfg.MisskeyHost, cfg.MisskeyToken, tweet.MediaURLs[i], cfg.TwitterMediaAllowedHosts)
-		if err != nil {
-			slog.Error("Failed to upload tweet media to Misskey Drive",
-				slog.String("media_url", tweet.MediaURLs[i]),
-				slog.Any("error", err))
-			m.Tweet2NoteErrors.Inc()
-			return err
+	var fileIDs []string
+	if !tweet.IsRetweet {
+		fileIDs = make([]string, 0, min(len(tweet.MediaURLs), 4))
+		for i := 0; i < len(tweet.MediaURLs) && i < 4; i++ {
+			fileID, err := uploadMisskeyDriveFileFromURL(ctx, cfg.MisskeyHost, cfg.MisskeyToken, tweet.MediaURLs[i], cfg.TwitterMediaAllowedHosts)
+			if err != nil {
+				slog.Error("Failed to upload tweet media to Misskey Drive",
+					slog.String("media_url", tweet.MediaURLs[i]),
+					slog.Any("error", err))
+				m.Tweet2NoteErrors.Inc()
+				return err
+			}
+			fileIDs = append(fileIDs, fileID)
 		}
-		fileIDs = append(fileIDs, fileID)
 	}
 
 	noteID, err := createMisskeyNoteWithOptions(ctx, cfg.MisskeyHost, cfg.MisskeyToken, misskey.CreateNoteOptions{
@@ -263,7 +267,11 @@ func parseFilteredStreamPayloadWithConfig(data []byte, cfg Config) ([]IncomingTw
 	}
 
 	text := payload.Data.Text
-	mediaURLs := filteredStreamMediaURLs(payload)
+	isRetweet := filteredStreamRetweetedTweetID(payload) != ""
+	var mediaURLs []string
+	if !isRetweet {
+		mediaURLs = filteredStreamMediaURLs(payload)
+	}
 	if text == "" && len(mediaURLs) == 0 {
 		return nil, nil
 	}
@@ -285,6 +293,7 @@ func parseFilteredStreamPayloadWithConfig(data []byte, cfg Config) ([]IncomingTw
 		Username:         username,
 		URL:              tweetURL,
 		MediaURLs:        mediaURLs,
+		IsRetweet:        isRetweet,
 		QuotedTweetID:    quotedTweetID,
 		QuotedUserID:     quotedUserID,
 		QuotedUsername:   quotedUsername,
@@ -365,19 +374,22 @@ func filteredStreamQuote(payload filteredStreamPayload) (tweetID, userID, userna
 }
 
 func filteredStreamRetweetURL(payload filteredStreamPayload) string {
-	var retweetedTweetID string
-	for _, ref := range payload.Data.ReferencedTweets {
-		if ref.Type == "retweeted" {
-			retweetedTweetID = ref.ID
-			break
-		}
-	}
+	retweetedTweetID := filteredStreamRetweetedTweetID(payload)
 	if retweetedTweetID == "" {
 		return ""
 	}
 	for _, tweet := range payload.Includes.Tweets {
 		if tweet.ID == retweetedTweetID {
 			return buildTweetURL(filteredStreamUsername(payload, tweet.AuthorID), retweetedTweetID)
+		}
+	}
+	return ""
+}
+
+func filteredStreamRetweetedTweetID(payload filteredStreamPayload) string {
+	for _, ref := range payload.Data.ReferencedTweets {
+		if ref.Type == "retweeted" {
+			return ref.ID
 		}
 	}
 	return ""

--- a/internal/handler/tweet2note_test.go
+++ b/internal/handler/tweet2note_test.go
@@ -211,12 +211,15 @@ func TestParseFilteredStreamPayload(t *testing.T) {
 			},
 		},
 		{
-			name: "retweet uses referenced tweet URL",
+			name: "retweet uses referenced tweet URL and skips media",
 			payload: `{
 					"data": {
 						"id": "123456789",
 						"text": "RT @other_user: original text",
 						"author_id": "111",
+						"attachments": {
+							"media_keys": ["photo-1"]
+						},
 						"referenced_tweets": [
 							{
 								"type": "retweeted",
@@ -230,6 +233,13 @@ func TestParseFilteredStreamPayload(t *testing.T) {
 								"id": "987654321",
 								"text": "original text",
 								"author_id": "222"
+							}
+						],
+						"media": [
+							{
+								"media_key": "photo-1",
+								"type": "photo",
+								"url": "https://pbs.twimg.com/media/retweet.png"
 							}
 						],
 						"users": [
@@ -250,6 +260,12 @@ func TestParseFilteredStreamPayload(t *testing.T) {
 				}
 				if tweets[0].URL != "https://twitter.com/other_user/status/987654321" {
 					t.Fatalf("URL = %q", tweets[0].URL)
+				}
+				if !tweets[0].IsRetweet {
+					t.Fatal("IsRetweet = false, want true")
+				}
+				if len(tweets[0].MediaURLs) != 0 {
+					t.Fatalf("MediaURLs = %#v, want empty for retweet", tweets[0].MediaURLs)
 				}
 			},
 		},
@@ -344,6 +360,50 @@ func TestHandleIncomingTweet_WithMedia(t *testing.T) {
 	}
 	if ok, err := crossPostTracker.HasMisskeyNote(ctx, "note-123"); err != nil || !ok {
 		t.Fatal("note ID was not recorded")
+	}
+}
+
+func TestHandleIncomingTweet_RetweetSkipsMediaUpload(t *testing.T) {
+	ctx := context.Background()
+	crossPostTracker := tracker.NewCrossPostTracker(ctx, 1*time.Hour)
+	m := metrics.NewNoop()
+
+	oldCreate := createMisskeyNoteWithOptions
+	oldUpload := uploadMisskeyDriveFileFromURL
+	defer func() {
+		createMisskeyNoteWithOptions = oldCreate
+		uploadMisskeyDriveFileFromURL = oldUpload
+	}()
+
+	uploadMisskeyDriveFileFromURL = func(ctx context.Context, host, token, fileURL string, allowedHosts []string) (string, error) {
+		t.Fatal("UploadDriveFileFromURLWithAllowedHosts should not be called for a retweet")
+		return "", nil
+	}
+
+	var gotOptions misskey.CreateNoteOptions
+	createMisskeyNoteWithOptions = func(ctx context.Context, host, token string, options misskey.CreateNoteOptions) (string, error) {
+		gotOptions = options
+		return "note-123", nil
+	}
+
+	tweet := IncomingTweet{
+		ID:        "123",
+		Text:      "RT @other_user: original text",
+		Username:  "dummy_user",
+		URL:       "https://twitter.com/other_user/status/456",
+		MediaURLs: []string{"https://pbs.twimg.com/media/retweet.png"},
+		IsRetweet: true,
+	}
+
+	if err := HandleIncomingTweetWithConfig(ctx, testHandlerConfig(), tweet, crossPostTracker, m); err != nil {
+		t.Fatalf("HandleIncomingTweet() error = %v", err)
+	}
+	wantText := "RT @other_user: original text\n\nhttps://twitter.com/other_user/status/456"
+	if gotOptions.Text != wantText {
+		t.Fatalf("Text = %q, want %q", gotOptions.Text, wantText)
+	}
+	if len(gotOptions.FileIDs) != 0 {
+		t.Fatalf("FileIDs = %#v, want empty", gotOptions.FileIDs)
 	}
 }
 


### PR DESCRIPTION
- README.md: リツイート時のメディアアップロードをスキップする旨を追記
- tweet2note.go: IncomingTweet構造体にIsRetweetフィールドを追加し、リツイート時のメディア処理を変更
- tweet2note_test.go: リツイート時にメディアアップロードが行われないことを確認するテストを追加